### PR TITLE
Parse member expression spreads

### DIFF
--- a/examples/nested-spread.ts
+++ b/examples/nested-spread.ts
@@ -1,0 +1,16 @@
+import { createMachine, MachineConfig } from "xstate";
+
+const config: MachineConfig<any, any, any> = {
+  states: {
+    a: { always: { target: "b" } },
+    b: { type: "final" },
+  },
+};
+
+export const nestedSpreadMachine = createMachine({
+  initial: "A",
+  states: {
+    A: { ...config },
+    B: { ...config, states: { ...config.states, c: {} } },
+  },
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,10 +129,10 @@ export const spreadElement = <Result>(parser: AnyParser<Result>) => {
   });
 };
 
-export const spreadElementReferencingIdentifier = <Result>(
+export const spreadElementReferencingIdentifierOrMemberExpression = <Result>(
   parser: AnyParser<Result>,
 ) => {
-  return spreadElement(identifierReferencingVariableDeclaration(parser));
+  return spreadElement(maybeIdentifierTo(parser));
 };
 
 export const dynamicObjectProperty = <KeyResult>(
@@ -211,12 +211,13 @@ export const getPropertiesOfObjectExpression = (
       | t.SpreadElement
     )[] = [property];
 
-    const spreadElementResult = spreadElementReferencingIdentifier(
-      createParser({
-        babelMatcher: t.isObjectExpression,
-        parseNode: (node) => node,
-      }),
-    ).parse(property, context);
+    const spreadElementResult =
+      spreadElementReferencingIdentifierOrMemberExpression(
+        createParser({
+          babelMatcher: t.isObjectExpression,
+          parseNode: (node) => node,
+        }),
+      ).parse(property, context)
 
     propertiesToParse.push(
       ...(spreadElementResult?.argumentResult?.properties || []),


### PR DESCRIPTION
This PR resolves #9 by updating `spreadElementReferencingIdentifer` to use `maybeIdentifierTo` instead of `identifierReferencingVariableDeclaration`. 

Previously, we were only handling `Identifier` (`…object`) spreads. With this change, we also handle `MemberExpression` (`…object.key`) spreads.

Also renamed `spreadElementReferencingIdentifier` to `spreadElementReferencingIdentifierOrMemberExpression` to reflect this change in behavior.

And added a test that matches #9 to validate.